### PR TITLE
Fix Claude GitHub Action permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Update Claude GitHub Action workflow permissions from `read` to `write` for pull-requests and issues
- This fix enables the Claude bot to post comments when mentioned with @claude

## Test plan
- [ ] Comment @claude on this PR to test the bot responds correctly
- [ ] Verify the workflow runs without permission errors
- [ ] Check that Claude can post a comment back to the PR

🤖 Generated with [Claude Code](https://claude.ai/code)