### PR TITLE
fix: correct uvicorn module reference from main_refactored to server_…

### DIFF
--- a/server-side/server_side/main.py
+++ b/server-side/server_side/main.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(
-        "main_refactored:app",
+        "server_side.main:app",
         host=settings.host,
         port=settings.port,
         reload=settings.debug,


### PR DESCRIPTION
This pull request updates the entrypoint for the Uvicorn server in `server_side/main.py` to reference the correct application module.

* Entrypoint Update:
  * Changed the Uvicorn run target from `"main_refactored:app"` to `"server_side.main:app"`, ensuring the server launches the intended FastAPI application.…side.main