### PR TITLE
fix: restore value comparison feature for city migration analysis

### DIFF
--- a/client-side/src/context/DataContext.tsx
+++ b/client-side/src/context/DataContext.tsx
@@ -34,9 +34,9 @@ interface DataProviderProps {
 }
 
 export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
-  const { selectedCity } = useCitySelection();
-  const happinessData = useHappinessData(selectedCity);
-  const costOfLivingData = useCostOfLivingData(selectedCity);
+  const { selectedCity, comparisonCity } = useCitySelection();
+  const happinessData = useHappinessData(selectedCity, comparisonCity);
+  const costOfLivingData = useCostOfLivingData(selectedCity, comparisonCity);
 
   const getFilteredDataForCity = (
     cityName: string,

--- a/client-side/src/hooks/useCostOfLivingData.ts
+++ b/client-side/src/hooks/useCostOfLivingData.ts
@@ -11,6 +11,7 @@ export interface UseCostOfLivingDataResult {
 
 export const useCostOfLivingData = (
   city: string,
+  comparisonCity?: string,
 ): UseCostOfLivingDataResult => {
   const [data, setData] = useState<CostOfLivingItem[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -25,7 +26,7 @@ export const useCostOfLivingData = (
     try {
       setLoading(true);
       setError(null);
-      const result = await dataApi.getCostOfLiving(city);
+      const result = await dataApi.getCostOfLiving(city, comparisonCity);
 
       if (result && Array.isArray(result)) {
         setData(result);
@@ -46,7 +47,7 @@ export const useCostOfLivingData = (
 
   useEffect(() => {
     fetchData();
-  }, [city]);
+  }, [city, comparisonCity]);
 
   return {
     data,

--- a/client-side/src/hooks/useHappinessData.ts
+++ b/client-side/src/hooks/useHappinessData.ts
@@ -9,7 +9,7 @@ export interface UseHappinessDataResult {
   refetch: () => Promise<void>;
 }
 
-export const useHappinessData = (city: string): UseHappinessDataResult => {
+export const useHappinessData = (city: string, comparisonCity?: string): UseHappinessDataResult => {
   const [data, setData] = useState<HappinessQolItem[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -23,7 +23,7 @@ export const useHappinessData = (city: string): UseHappinessDataResult => {
     try {
       setLoading(true);
       setError(null);
-      const result = await dataApi.getHappinessQol(city);
+      const result = await dataApi.getHappinessQol(city, comparisonCity);
       setData(result);
     } catch (err) {
       const errorMessage =
@@ -37,7 +37,7 @@ export const useHappinessData = (city: string): UseHappinessDataResult => {
 
   useEffect(() => {
     fetchData();
-  }, [city]);
+  }, [city, comparisonCity]);
 
   return {
     data,

--- a/client-side/src/services/api/dataApi.ts
+++ b/client-side/src/services/api/dataApi.ts
@@ -6,15 +6,27 @@ export class DataApiService extends BaseApiService {
     super(baseURL);
   }
 
-  async getHappinessQol(city: string): Promise<HappinessQolItem[]> {
+  async getHappinessQol(city: string, comparisonCity?: string): Promise<HappinessQolItem[]> {
     const formattedCity = encodeURIComponent(city.toLowerCase().trim());
-    return this.get<HappinessQolItem[]>(`/happiness_qol?city=${formattedCity}`);
+    let url = `/happiness_qol?city=${formattedCity}`;
+    
+    if (comparisonCity) {
+      const formattedComparisonCity = encodeURIComponent(comparisonCity.toLowerCase().trim());
+      url += `&comparison_city=${formattedComparisonCity}`;
+    }
+    
+    return this.get<HappinessQolItem[]>(url);
   }
 
-  async getCostOfLiving(city: string): Promise<CostOfLivingItem[]> {
+  async getCostOfLiving(city: string, comparisonCity?: string): Promise<CostOfLivingItem[]> {
     const formattedCity = encodeURIComponent(city.toLowerCase().trim());
-    return this.get<CostOfLivingItem[]>(
-      `/cost_of_living?city=${formattedCity}`,
-    );
+    let url = `/cost_of_living?city=${formattedCity}`;
+    
+    if (comparisonCity) {
+      const formattedComparisonCity = encodeURIComponent(comparisonCity.toLowerCase().trim());
+      url += `&comparison_city=${formattedComparisonCity}`;
+    }
+    
+    return this.get<CostOfLivingItem[]>(url);
   }
 }

--- a/server-side/server_side/main.py
+++ b/server-side/server_side/main.py
@@ -55,14 +55,30 @@ async def get_country(city: str):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/happiness_qol")
-async def get_happiness_qol(city: str):
+async def get_happiness_qol(city: str, comparison_city: str = None):
     """Get happiness and quality of life data."""
     city = city.lower().strip()
     try:
         data = load_json_data("summary/happiness_qol.json")
-        result = [item for item in data if item.get("city", "").lower() == city]
-        if not result:
+        
+        # Get data for the selected city
+        selected_city_data = [item for item in data if item.get("city", "").lower() == city]
+        if not selected_city_data:
             raise HTTPException(status_code=404, detail=f"No data found for city: {city}")
+        
+        # Transform selected city data to have value_in_current_city
+        result = []
+        for item in selected_city_data:
+            transformed_item = item.copy()
+            transformed_item["value_in_current_city"] = item["value"]
+            result.append(transformed_item)
+        
+        # If comparison city is provided, add its data with original structure
+        if comparison_city:
+            comparison_city = comparison_city.lower().strip()
+            comparison_data = [item for item in data if item.get("city", "").lower() == comparison_city]
+            result.extend(comparison_data)
+        
         return result
     except HTTPException:
         raise
@@ -70,14 +86,30 @@ async def get_happiness_qol(city: str):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/cost_of_living")
-async def get_cost_of_living(city: str):
+async def get_cost_of_living(city: str, comparison_city: str = None):
     """Get cost of living data."""
     city = city.lower().strip()
     try:
         data = load_json_data("summary/cost_of_living.json")
-        result = [item for item in data if item.get("city", "").lower() == city]
-        if not result:
+        
+        # Get data for the selected city
+        selected_city_data = [item for item in data if item.get("city", "").lower() == city]
+        if not selected_city_data:
             raise HTTPException(status_code=404, detail=f"No data found for city: {city}")
+        
+        # Transform selected city data to have value_in_current_city
+        result = []
+        for item in selected_city_data:
+            transformed_item = item.copy()
+            transformed_item["value_in_current_city"] = item["value"]
+            result.append(transformed_item)
+        
+        # If comparison city is provided, add its data with original structure
+        if comparison_city:
+            comparison_city = comparison_city.lower().strip()
+            comparison_data = [item for item in data if item.get("city", "").lower() == comparison_city]
+            result.extend(comparison_data)
+        
         return result
     except HTTPException:
         raise


### PR DESCRIPTION
Restores the missing city comparison functionality that was accidentally removed during refactoring.

## Changes
- Add comparison_city parameter to API endpoints
- Update client-side code to handle comparison data
- Preserve sign-to-migrate renaming

Resolves #18

🤖 Generated with [Claude Code](https://claude.ai/code)